### PR TITLE
Add code coverage and upload to Codecov jobs

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -10,8 +10,17 @@ env:
 jobs:
   test:
     runs-on: ubuntu-latest
-
     steps:
     - uses: actions/checkout@v4
     - name: Run tests
       run: cargo test --verbose
+    - name: Install cargo-llvm-cov
+      uses: taiki-e/install-action@cargo-llvm-cov
+    - name: Generate code coverage
+      run: cargo llvm-cov --all-features --codecov --output-path codecov.json --ignore-filename-regex main
+    - name: Upload coverage to Codecov
+      uses: codecov/codecov-action@v3
+      with:
+        token: ${{ secrets.CODECOV_TOKEN }} # not required for public repos
+        files: codecov.json
+        fail_ci_if_error: true


### PR DESCRIPTION
This pull request adds code coverage job to the CI pipeline. After the code coverage report is made, it will be uploaded to Codecov.

Before merging this you need to create a new account on Codecov and add a repository secret named `CODECOV_TOKEN` with the value provided by Codecov.

Note: the code coverage does not cover the `main.rs` file.